### PR TITLE
Minor tweaks for JEDI in WAVEMQ

### DIFF
--- a/eapi/pbconversions.go
+++ b/eapi/pbconversions.go
@@ -286,7 +286,7 @@ func (e *EAPI) ConvertPolicy(in *pb.Policy) (iapi.PolicySchemeInstance, wve.WVE)
 		spol.Namespace = *ext
 
 		//Try locate the namespace
-		eng := e.getEngineNoPerspective()
+		eng := e.GetEngineNoPerspective()
 		found := false
 		locz, err := iapi.SI().RegisteredLocations(context.Background())
 		if err != nil {

--- a/iapi/keyschemes.go
+++ b/iapi/keyschemes.go
@@ -6,7 +6,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/immesys/asn1"
 	"github.com/immesys/wave/serdes"
-	"github.com/ucbrise/jedi-pairing/lang/go/bls12381"
 	wkdutils "github.com/ucbrise/jedi-pairing/lang/go/cryptutils"
 	lqibe "github.com/ucbrise/jedi-pairing/lang/go/lqibe"
 	"github.com/ucbrise/jedi-pairing/lang/go/wkdibe"
@@ -1585,11 +1583,7 @@ func slotsToAttrMap(id [][]byte) wkdibe.AttributeList {
 	rv := make(map[wkdibe.AttributeIndex]*big.Int)
 	for index, arr := range id {
 		if len(arr) > 0 {
-			digest := sha256.Sum256(arr)
-			bigint := new(big.Int).SetBytes(digest[:])
-			bigint.Mod(bigint, new(big.Int).Add(bls12381.GroupOrder, big.NewInt(-1)))
-			bigint.Add(bigint, big.NewInt(1))
-			rv[wkdibe.AttributeIndex(index)] = bigint
+			rv[wkdibe.AttributeIndex(index)] = wkdutils.HashToZp(new(big.Int), arr)
 		}
 	}
 	return rv


### PR DESCRIPTION
I'm not done implementing JEDI for WAVEMQ, but rather than producing a possibly massive commit containing everything, I thought it might be better to merge the PRs in incrementally.

Summary of changes:
* Makes GetEngine and GetEngineNoPerspective public
* Uses cryptutils hash for assembling attribute maps

Happy to discuss if any of these changes aren't OK to make.