### PR TITLE
JEDI Delegation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -758,6 +758,17 @@
   revision = "4c3d16d2a74fea69e1e9693dcc5353e9889757e5"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a9a562133862eb5fe42a8b7a76729c087211157dc1c1721efb0d177b12749b17"
+  name = "github.com/ucbrise/jedi-protocol"
+  packages = [
+    "core",
+    "crypto/roaque/csroaque/optimized",
+  ]
+  pruneopts = "T"
+  revision = "7187fb0b5b8a0f744600940b62b4a1466965e677"
+
+[[projects]]
   digest = "1:a4ef215bd846f9407d095f526879cb232330e1e7a748c70e384f775a6a64fd3e"
   name = "github.com/urfave/cli"
   packages = ["."]
@@ -796,8 +807,12 @@
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
+    "internal/subtle",
+    "nacl/secretbox",
     "pbkdf2",
+    "poly1305",
     "ripemd160",
+    "salsa20/salsa",
     "scrypt",
     "sha3",
     "ssh/terminal",
@@ -1105,10 +1120,10 @@
     "github.com/syndtr/goleveldb/leveldb",
     "github.com/syndtr/goleveldb/leveldb/util",
     "github.com/tinylib/msgp/msgp",
-    "github.com/ucbrise/jedi-pairing/lang/go/bls12381",
     "github.com/ucbrise/jedi-pairing/lang/go/cryptutils",
     "github.com/ucbrise/jedi-pairing/lang/go/lqibe",
     "github.com/ucbrise/jedi-pairing/lang/go/wkdibe",
+    "github.com/ucbrise/jedi-protocol/core",
     "github.com/urfave/cli",
     "golang.org/x/crypto/curve25519",
     "golang.org/x/crypto/ed25519",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -759,11 +759,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:32e46c6715769ffb19959596ffc30c5a5dfe73287903f81734f21b0c8ca8aad9"
+  digest = "1:81346cbbaf2dfb1887e53f0fc1900ea1fe2233c7da8b5d169d87080a3064d1d9"
   name = "github.com/ucbrise/jedi-protocol-go"
   packages = ["."]
   pruneopts = "T"
-  revision = "14cba6ef5407988e85ded87b5ca9db94f89ea320"
+  revision = "5b11ad625ee5f1b1f4fc1381d4293f54a2e52b3c"
 
 [[projects]]
   digest = "1:a4ef215bd846f9407d095f526879cb232330e1e7a748c70e384f775a6a64fd3e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -759,11 +759,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b9842cfc77114784a1297d5627399c366f89e42c0aed1cb01b8ee832ca8c6811"
+  digest = "1:32e46c6715769ffb19959596ffc30c5a5dfe73287903f81734f21b0c8ca8aad9"
   name = "github.com/ucbrise/jedi-protocol-go"
   packages = ["."]
   pruneopts = "T"
-  revision = "0c76dc4f47f7106047c2e46e945019905efa4cf0"
+  revision = "14cba6ef5407988e85ded87b5ca9db94f89ea320"
 
 [[projects]]
   digest = "1:a4ef215bd846f9407d095f526879cb232330e1e7a748c70e384f775a6a64fd3e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -759,14 +759,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a9a562133862eb5fe42a8b7a76729c087211157dc1c1721efb0d177b12749b17"
-  name = "github.com/ucbrise/jedi-protocol"
-  packages = [
-    "core",
-    "crypto/roaque/csroaque/optimized",
-  ]
+  digest = "1:b9842cfc77114784a1297d5627399c366f89e42c0aed1cb01b8ee832ca8c6811"
+  name = "github.com/ucbrise/jedi-protocol-go"
+  packages = ["."]
   pruneopts = "T"
-  revision = "7187fb0b5b8a0f744600940b62b4a1466965e677"
+  revision = "0c76dc4f47f7106047c2e46e945019905efa4cf0"
 
 [[projects]]
   digest = "1:a4ef215bd846f9407d095f526879cb232330e1e7a748c70e384f775a6a64fd3e"
@@ -807,12 +804,8 @@
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
-    "internal/subtle",
-    "nacl/secretbox",
     "pbkdf2",
-    "poly1305",
     "ripemd160",
-    "salsa20/salsa",
     "scrypt",
     "sha3",
     "ssh/terminal",
@@ -1123,7 +1116,7 @@
     "github.com/ucbrise/jedi-pairing/lang/go/cryptutils",
     "github.com/ucbrise/jedi-pairing/lang/go/lqibe",
     "github.com/ucbrise/jedi-pairing/lang/go/wkdibe",
-    "github.com/ucbrise/jedi-protocol/core",
+    "github.com/ucbrise/jedi-protocol-go",
     "github.com/urfave/cli",
     "golang.org/x/crypto/curve25519",
     "golang.org/x/crypto/ed25519",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -147,3 +147,7 @@
 
 [prune]
   go-tests = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/ucbrise/jedi-protocol-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -134,10 +134,6 @@
   name = "golang.org/x/net"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/ucbrise/jedi-pairing"
-
-[[constraint]]
   name = "google.golang.org/grpc"
   version = "1.13.0"
 

--- a/cli/actions.go
+++ b/cli/actions.go
@@ -784,6 +784,10 @@ func resolveEntityNameOrHashOrFile(conn pb.WAVEClient, perspective *pb.Perspecti
 			return rv
 		} else if in == "wavemq" {
 			return []byte("\x1b\x20\x14\x33\x74\xb3\x2f\xd2\x74\x39\x54\xfe\x47\x86\xf6\xcf\x86\xd4\x03\x72\x0f\x5e\xc4\x42\x36\xb6\x58\xc2\x6a\x1e\x68\x0f\x6e\x01")
+		} else if in == "jedi" {
+			rv := make([]byte, len(consts.JEDIBuiltinPSETByteArray))
+			copy(rv, consts.JEDIBuiltinPSETByteArray)
+			return rv
 		}
 
 		resp, err := conn.ResolveName(context.Background(), &pb.ResolveNameParams{

--- a/consts/params.go
+++ b/consts/params.go
@@ -24,5 +24,11 @@ var WAVEMQPSETBytes = "\x1b\x20\x14\x33\x74\xb3\x2f\xd2\x74\x39\x54\xfe\x47\x86\
 //to decrypt end-to-end encrypted messages
 var WaveBuiltinE2EE = "decrypt"
 
+// This is the JEDI built-in permission set.
+var JEDIBuiltinPSET = "GyAdzlOf-YTN8eq9Fw0-S0XQ_Lh2KL0HCBrDQTvqiDe88A=="
+var JEDIBuiltinPSETByteArray = []byte{27, 32, 29, 206, 83, 159, 249, 132, 205, 241, 234, 189, 23, 13, 62, 75, 69, 208, 252, 184, 118, 40, 189, 7, 8, 26, 195, 65, 59, 234, 136, 55, 188, 240}
+var JEDIBuiltinDecrypt = "decrypt"
+var JEDIBuiltinSign = "sign"
+
 //This can actually be changed
 var DefaultToUnrevoked = false

--- a/eapi/pbconversions.go
+++ b/eapi/pbconversions.go
@@ -286,7 +286,7 @@ func (e *EAPI) ConvertPolicy(in *pb.Policy) (iapi.PolicySchemeInstance, wve.WVE)
 		spol.Namespace = *ext
 
 		//Try locate the namespace
-		eng := e.getEngineNoPerspective()
+		eng := e.GetEngineNoPerspective()
 		found := false
 		locz, err := iapi.SI().RegisteredLocations(context.Background())
 		if err != nil {

--- a/iapi/attestation.go
+++ b/iapi/attestation.go
@@ -11,8 +11,7 @@ import (
 	"github.com/immesys/wave/consts"
 	"github.com/immesys/wave/serdes"
 	"github.com/immesys/wave/wve"
-
-	jedi "github.com/ucbrise/jedi-protocol/core"
+	"github.com/ucbrise/jedi-protocol-go"
 )
 
 type PCreateAttestation struct {
@@ -260,7 +259,7 @@ func checkPolicyForSpecialCases(p PolicySchemeInstance) wve.WVE {
 					}
 
 					if perm != consts.JEDIBuiltinDecrypt && perm != consts.JEDIBuiltinSign {
-						return wve.Err(wve.InvalidJEDIGrant, fmt.Sprintf("the only valid jedi grants are '%s' and '%s'", consts.JEDIBuiltinDecrypt, consts.JEDIBuiltinSign))
+						return wve.Err(wve.InvalidJEDIGrant, fmt.Sprintf("the only valid JEDI grants are '%s' and '%s'", consts.JEDIBuiltinDecrypt, consts.JEDIBuiltinSign))
 					}
 					seen[perm] = struct{}{}
 				}
@@ -268,10 +267,11 @@ func checkPolicyForSpecialCases(p PolicySchemeInstance) wve.WVE {
 				if err2 != nil {
 					return wve.Err(wve.InvalidJEDIGrant, fmt.Sprintf("Invalid URI for JEDI grant: '%s'", err2.Error()))
 				}
-				rtree.VisibilityURI = make([][]byte, len(uri))
-				for i, comp := range uri {
-					rtree.VisibilityURI[i] = comp.Representation()
+				rtree.VisibilityURI = make([][]byte, 11)
+				if len(uri) > len(rtree.VisibilityURI) {
+					return wve.Err(wve.InvalidJEDIGrant, "URI is too long for a JEDI grant")
 				}
+				jedi.EncodeURIPathInto(uri, rtree.VisibilityURI)
 			}
 		}
 	}

--- a/iapi/attestation.go
+++ b/iapi/attestation.go
@@ -11,6 +11,8 @@ import (
 	"github.com/immesys/wave/consts"
 	"github.com/immesys/wave/serdes"
 	"github.com/immesys/wave/wve"
+
+	jedi "github.com/ucbrise/jedi-protocol/core"
 )
 
 type PCreateAttestation struct {
@@ -237,18 +239,40 @@ func checkPolicyForSpecialCases(p PolicySchemeInstance) wve.WVE {
 	var res string
 	for _, s := range rtree.SerdesForm.Statements {
 		hi := HashSchemeInstanceFor(&s.PermissionSet)
-		if hi.Supported() && hi.MultihashString() == consts.WaveBuiltinPSET {
-			foundE2E = true
-			if len(s.Permissions) == 0 {
-				return wve.Err(wve.InvalidE2EEGrant, "a wave pset grant must have exactly one permission")
+		if hi.Supported() {
+			if hi.MultihashString() == consts.WaveBuiltinPSET {
+				foundE2E = true
+				if len(s.Permissions) == 0 {
+					return wve.Err(wve.InvalidE2EEGrant, "a wave pset grant must have exactly one permission")
+				}
+				if len(s.Permissions) > 1 {
+					return wve.Err(wve.InvalidE2EEGrant, "a wave:decrypt grant can only have one permission and one statement")
+				}
+				if s.Permissions[0] != consts.WaveBuiltinE2EE {
+					return wve.Err(wve.InvalidE2EEGrant, "the only valid wave pset permissions is 'decrypt'")
+				}
+				res = s.Resource
+			} else if hi.MultihashString() == consts.JEDIBuiltinPSET {
+				seen := make(map[string]struct{})
+				for _, perm := range s.Permissions {
+					if _, ok := seen[perm]; ok {
+						return wve.Err(wve.InvalidJEDIGrant, fmt.Sprintf("permission '%s' repeats", perm))
+					}
+
+					if perm != consts.JEDIBuiltinDecrypt && perm != consts.JEDIBuiltinSign {
+						return wve.Err(wve.InvalidJEDIGrant, fmt.Sprintf("the only valid jedi grants are '%s' and '%s'", consts.JEDIBuiltinDecrypt, consts.JEDIBuiltinSign))
+					}
+					seen[perm] = struct{}{}
+				}
+				uri, err2 := jedi.ParseURI(s.Resource)
+				if err2 != nil {
+					return wve.Err(wve.InvalidJEDIGrant, fmt.Sprintf("Invalid URI for JEDI grant: '%s'", err2.Error()))
+				}
+				rtree.VisibilityURI = make([][]byte, len(uri))
+				for i, comp := range uri {
+					rtree.VisibilityURI[i] = comp.Representation()
+				}
 			}
-			if len(s.Permissions) > 1 {
-				return wve.Err(wve.InvalidE2EEGrant, "a wave:decrypt grant can only have one permission and one statement")
-			}
-			if s.Permissions[0] != consts.WaveBuiltinE2EE {
-				return wve.Err(wve.InvalidE2EEGrant, "the only valid wave pset permissions is 'decrypt'")
-			}
-			res = s.Resource
 		}
 	}
 	if !foundE2E {

--- a/iapi/bodyschemes.go
+++ b/iapi/bodyschemes.go
@@ -90,7 +90,7 @@ type WR1Extra struct {
 	ProverBodyKey   []byte
 
 	EnvelopeKey    []byte
-	JEDIDelegation *jedi.Delegation
+	JEDIDelegation []byte
 
 	//For NameDecl only
 	Namespace         HashSchemeInstance
@@ -221,7 +221,7 @@ func (w *WR1BodyScheme) DecryptBody(ctx context.Context, dc BodyDecryptionContex
 	}
 
 	//The key is actually 16 bytes of AES key + 12 bytes of GCM nonce
-	var jediDelegation *jedi.Delegation
+	var jediDelegation []byte
 	if len(envelopeKey) > 16+12 {
 		marshalled := envelopeKey[16+12:]
 		envelopeKey = envelopeKey[:16+12]
@@ -233,9 +233,7 @@ func (w *WR1BodyScheme) DecryptBody(ctx context.Context, dc BodyDecryptionContex
 		if len(marshalled) != 4+length {
 			return nil, nil, ErrDecryptBodyMalformed
 		}
-		if !jediDelegation.Unmarshal(marshalled[4:]) {
-			return nil, nil, ErrDecryptBodyMalformed
-		}
+		jediDelegation = marshalled[4:]
 	}
 	if len(envelopeKey) != 16+12 {
 		fmt.Printf("dc E\n")

--- a/iapi/bodyschemes.go
+++ b/iapi/bodyschemes.go
@@ -522,7 +522,6 @@ func (w *WR1BodyScheme) EncryptBody(ctx context.Context, ecp BodyEncryptionConte
 		}
 		jediDelegation, err2 = jedi.DelegateParsed(ctx, reader, jediutils.WAVEPatternEncoderSingleton, jediNS.Multihash(), uriPath, rangeTimePaths, perm)
 		if err2 != nil {
-			fmt.Println("Error here")
 			return nil, nil, err2
 		}
 	}
@@ -576,11 +575,6 @@ func (w *WR1BodyScheme) EncryptBody(ctx context.Context, ecp BodyEncryptionConte
 							//fmt.Printf("Key %d was ok: %v\n", idx, e2ePartitions[idx])
 							cf := sk.SecretCanonicalForm()
 							e2eDelegatedBundle[idx].Key = cf.Private.Content.(serdes.EntitySecretOQAUE_BLS12381_s20)
-						} else if jediDecrypt || jediSign {
-							// We weren't able to generate the key --- return error to user.
-							//fmt.Printf("Couldn't find key for %v\n", e2ePartitions[idx])
-							workererrs[i] = errors.New("Could not generate key: requisite delegation(s) not received")
-							break
 						}
 					}
 				}

--- a/iapi/bodyschemes.go
+++ b/iapi/bodyschemes.go
@@ -15,7 +15,7 @@ import (
 	"github.com/immesys/wave/serdes"
 	"github.com/immesys/wave/wve"
 
-	jedi "github.com/ucbrise/jedi-protocol/core"
+	"github.com/ucbrise/jedi-protocol-go"
 )
 
 var ErrDecryptBodyMalformed = errors.New("body is malformed")
@@ -497,17 +497,15 @@ func (w *WR1BodyScheme) EncryptBody(ctx context.Context, ecp BodyEncryptionConte
 		if !ok {
 			panic("Trying to apply JEDI to non-RTree policy")
 		}
+		uriPath := jedi.DecodeURIPathFrom(rtree.VisibilityURI)
 		for i, timePath := range rangeTimePaths {
 			path := make([][]byte, 20)
-			for j, comp := range timePath {
-				path[len(path)-jedi.MaxTimeLength+j] = comp.Representation()
-			}
-			copy(path[1:len(path)-jedi.MaxTimeLength], rtree.VisibilityURI)
 			if jediDecrypt {
 				path[0] = []byte("\x00jedi:decrypt")
 			} else {
 				path[0] = []byte("\x00jedi:sign")
 			}
+			jedi.EncodePattern(uriPath, timePath, path[1:])
 			paths = append(paths, path)
 
 			if jediDecrypt && jediSign {

--- a/iapi/jedi.go
+++ b/iapi/jedi.go
@@ -1,0 +1,46 @@
+package iapi
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ucbrise/jedi-pairing/lang/go/wkdibe"
+	"github.com/ucbrise/jedi-protocol-go"
+)
+
+// WR1JEDIKeyRetriever describes an object that can retrieve JEDI keys from an
+// entity's local storage, among those used in WR1.
+type WR1JEDIKeyRetriever interface {
+	WR1OAQUEKeysForContent(ctx context.Context, dst HashSchemeInstance, delegable bool, slots [][]byte, onResult func(k SlottedSecretKey) bool) error
+}
+
+// WR1JEDIKeyStoreReader lifts a WR1JEDIKeyRetriever to the jedi.KeyStoreReader
+// interface.
+type WR1JEDIKeyStoreReader struct {
+	WR1JEDIKeyRetriever
+}
+
+// KeyForPattern retrieves a key whose pattern matches the one provided as
+// input, within the provided namespace.
+func (jksr *WR1JEDIKeyStoreReader) KeyForPattern(ctx context.Context, namespace []byte, pattern jedi.Pattern) (*wkdibe.Params, *wkdibe.SecretKey, error) {
+	var nsHash HashSchemeInstance
+	if nsHash = HashSchemeInstanceFromMultihash(namespace); !nsHash.Supported() {
+		return nil, nil, errors.New("could not parse namespace")
+	}
+
+	var params *wkdibe.Params
+	var key *wkdibe.SecretKey
+	var err error
+	if err = jksr.WR1OAQUEKeysForContent(ctx, nsHash, false, pattern, func(k SlottedSecretKey) bool {
+		wrapped, ok := k.(*EntitySecretKey_OAQUE_BLS12381_S20)
+		if ok {
+			params = wrapped.Params
+			key = wrapped.PrivateKey
+			return false
+		}
+		return false
+	}); err != nil {
+		return nil, nil, err
+	}
+	return params, key, nil
+}

--- a/iapi/keyschemes.go
+++ b/iapi/keyschemes.go
@@ -6,7 +6,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/immesys/asn1"
 	"github.com/immesys/wave/serdes"
-	"github.com/ucbrise/jedi-pairing/lang/go/bls12381"
 	wkdutils "github.com/ucbrise/jedi-pairing/lang/go/cryptutils"
 	lqibe "github.com/ucbrise/jedi-pairing/lang/go/lqibe"
 	"github.com/ucbrise/jedi-pairing/lang/go/wkdibe"
@@ -1585,11 +1583,7 @@ func slotsToAttrMap(id [][]byte) wkdibe.AttributeList {
 	rv := make(map[wkdibe.AttributeIndex]*big.Int)
 	for index, arr := range id {
 		if len(arr) > 0 {
-			digest := sha256.Sum256(arr)
-			bigint := new(big.Int).SetBytes(digest[:])
-			bigint.Mod(bigint, new(big.Int).Add(bls12381.GroupOrder, big.NewInt(-1)))
-			bigint.Add(bigint, big.NewInt(1))
-			rv[wkdibe.AttributeIndex(index)] = bigint
+			rv[wkdibe.AttributeIndex(index)] = wkdutils.HashToZp(new(big.Int), arr)
 		}
 	}
 	return rv

--- a/iapi/objects.go
+++ b/iapi/objects.go
@@ -463,6 +463,25 @@ func (e *Attestation) WR1SecretSlottedKeys() []SlottedSecretKey {
 			wg.Wait()
 			rv = append(rv, erv...)
 		}
+		delegation := e.WR1Extra.JEDIDelegation
+		for i, key := range delegation.Keys {
+			ch := serdes.EntityPublicOAQUE_BLS12381_s20{
+				Params:       delegation.Params.Marshal(true),
+				AttributeSet: delegation.Patterns[i],
+			}
+			esk := &EntitySecretKey_OAQUE_BLS12381_S20{
+				SerdesForm: &serdes.EntityKeyringEntry{
+					Public: serdes.EntityPublicKey{
+						Capabilities: []int{int(CapEncryption)},
+						Key:          asn1.NewExternal(ch),
+					},
+				},
+				Params:       delegation.Params,
+				PrivateKey:   key,
+				AttributeSet: delegation.Patterns[i],
+			}
+			rv = append(rv, esk)
+		}
 	}
 	return rv
 }

--- a/iapi/wr1partition.go
+++ b/iapi/wr1partition.go
@@ -59,6 +59,10 @@ func CalculateEmptyKeyBundleEntries(startDat time.Time, endDat time.Time, userPr
 		return nil, nil, err
 	}
 
+	return partitions, CalculateEmptyKeyBundleEntriesFromPartitions(partitions), nil
+}
+
+func CalculateEmptyKeyBundleEntriesFromPartitions(partitions [][][]byte) []serdes.BLS12381OAQUEKeyringBundleEntry {
 	rv := make([]serdes.BLS12381OAQUEKeyringBundleEntry, len(partitions))
 	current := make([][]byte, 20)
 	for i := 0; i < len(partitions); i++ {
@@ -77,7 +81,7 @@ func CalculateEmptyKeyBundleEntries(startDat time.Time, endDat time.Time, userPr
 		}
 	}
 
-	return partitions, rv, nil
+	return rv
 }
 
 func DecodeKeyBundleEntries(be []serdes.BLS12381OAQUEKeyringBundleEntry) ([][][]byte, wve.WVE) {

--- a/jedistore/keystore.go
+++ b/jedistore/keystore.go
@@ -112,7 +112,7 @@ searchforkey:
 	if key == nil {
 		/* If we've already tried resyncing the graph, then give up. */
 		if synced {
-			return nil, nil, errors.New("could not find suitable key")
+			return nil, nil, nil
 		}
 
 		/* If not, resync the graph and try again. */

--- a/jedistore/keystore.go
+++ b/jedistore/keystore.go
@@ -1,0 +1,126 @@
+package jedistore
+
+import (
+	"context"
+	"errors"
+
+	"github.com/immesys/wave/eapi"
+	"github.com/immesys/wave/engine"
+	"github.com/immesys/wave/iapi"
+	"github.com/immesys/wave/serdes"
+	"github.com/immesys/wave/wve"
+	"github.com/ucbrise/jedi-pairing/lang/go/wkdibe"
+	"github.com/ucbrise/jedi-protocol-go"
+)
+
+// WAVEKeyStore implements the jedi.KeyStoreReader interface. It lifts a WAVE
+// entity's view of the attestation graph to JEDI's key storage interface. The
+// (abstract) key store consists of the keys in all attestations decryptable by
+// that WAVE entity.
+type WAVEKeyStore struct {
+	eng  *engine.Engine
+	wave *eapi.EAPI
+}
+
+// NewWAVEKeyStore creates and returns a new WAVEKeyStore. The entity whose
+// perpsective to use is implicit in the WAVE engine that is passed as an
+// argument to this function.
+func NewWAVEKeyStore(wave *eapi.EAPI, eng *engine.Engine) *WAVEKeyStore {
+	return &WAVEKeyStore{
+		eng:  eng,
+		wave: wave,
+	}
+}
+
+// ParamsForHierarchy accepts as input the multihash for a namespace (as the
+// "namespace" argument) and outputs the corresponding WKD-IBE parameters.
+func (wks *WAVEKeyStore) ParamsForHierarchy(ctx context.Context, namespace []byte) (*wkdibe.Params, error) {
+	var err error
+	var werr wve.WVE
+
+	/* Get the namespace entity. */
+
+	var nsHash iapi.HashSchemeInstance
+	if nsHash = iapi.HashSchemeInstanceFromMultihash(namespace); !nsHash.Supported() {
+		return nil, errors.New("could not parse namespace")
+	}
+
+	var nsLocation iapi.LocationSchemeInstance
+	if nsLocation, werr = eapi.LocationSchemeInstance(nil); werr != nil {
+		return nil, werr
+	}
+	if nsLocation == nil {
+		nsLocation = iapi.SI().DefaultLocation(ctx)
+	}
+
+	var nsEntity *iapi.Entity
+	var nsValidity *engine.Validity
+	if nsEntity, nsValidity, err = wks.eng.LookupEntity(ctx, nsHash, nsLocation); err != nil {
+		return nil, err
+	}
+	if !nsValidity.Valid {
+		return nil, errors.New("namespace entity is no longer valid")
+	}
+
+	/* Get the WKD-IBE public parameters from the namespace entity. */
+	params := new(wkdibe.Params)
+	for _, keyring := range nsEntity.Keys {
+		wrapped, ok := keyring.(*iapi.EntityKey_OAQUE_BLS12381_S20_Params)
+		if ok {
+			marshalled := wrapped.SerdesForm.Key.Content.(serdes.EntityParamsOQAUE_BLS12381_s20)
+			if params.Unmarshal(marshalled, true, false) {
+				return params, nil
+			}
+		}
+	}
+	return nil, errors.New("could not find WKD-IBE params in namespace entity")
+}
+
+// KeyForPattern retrieves a key whose pattern matches the one provided as
+// input, within the provided namespace. This function resyncs the graph as
+// necessary to query the most up-to-date information.
+func (wks *WAVEKeyStore) KeyForPattern(ctx context.Context, namespace []byte, pattern jedi.Pattern) (*wkdibe.Params, *wkdibe.SecretKey, error) {
+	var err error
+	var dctx *engine.EngineDecryptionContext
+
+	dctx = engine.NewEngineDecryptionContext(wks.eng)
+	dctx.AutoLoadPartitionSecrets(true)
+
+	var nsHash iapi.HashSchemeInstance
+	if nsHash = iapi.HashSchemeInstanceFromMultihash(namespace); !nsHash.Supported() {
+		return nil, nil, errors.New("could not parse namespace")
+	}
+
+	synced := false
+
+	var params *wkdibe.Params
+	var key *wkdibe.SecretKey
+searchforkey:
+	if err = dctx.WR1OAQUEKeysForContent(ctx, nsHash, false, pattern, func(k iapi.SlottedSecretKey) bool {
+		wrapped, ok := k.(*iapi.EntitySecretKey_OAQUE_BLS12381_S20)
+		if ok {
+			params = wrapped.Params
+			key = wrapped.PrivateKey
+			return false
+		}
+		return false
+	}); err != nil {
+		return nil, nil, err
+	}
+	if key == nil {
+		/* If we've already tried resyncing the graph, then give up. */
+		if synced {
+			return nil, nil, errors.New("could not find suitable key")
+		}
+
+		/* If not, resync the graph and try again. */
+		if err = wks.eng.ResyncEntireGraph(ctx); err != nil {
+			return nil, nil, err
+		}
+		<-wks.eng.WaitForEmptySyncQueue()
+		synced = true
+		goto searchforkey
+	}
+
+	return params, key, nil
+}

--- a/jedistore/keystore.go
+++ b/jedistore/keystore.go
@@ -13,28 +13,24 @@ import (
 	"github.com/ucbrise/jedi-protocol-go"
 )
 
-// WAVEKeyStore implements the jedi.KeyStoreReader interface. It lifts a WAVE
-// entity's view of the attestation graph to JEDI's key storage interface. The
-// (abstract) key store consists of the keys in all attestations decryptable by
-// that WAVE entity.
-type WAVEKeyStore struct {
-	eng  *engine.Engine
-	wave *eapi.EAPI
+// WAVEPublicInfo implements the jedi.PublicInfoReader interface. It lifts the
+// view of WAVE entity public information to JEDI's public parameters
+// interface.
+type WAVEPublicInfo struct {
+	eng *engine.Engine
 }
 
-// NewWAVEKeyStore creates and returns a new WAVEKeyStore. The entity whose
-// perpsective to use is implicit in the WAVE engine that is passed as an
-// argument to this function.
-func NewWAVEKeyStore(wave *eapi.EAPI, eng *engine.Engine) *WAVEKeyStore {
-	return &WAVEKeyStore{
-		eng:  eng,
-		wave: wave,
+// NewWAVEPublicInfo creates and returns a new WAVEPublicInfo. The provided
+// engine need not have a perspective.
+func NewWAVEPublicInfo(eng *engine.Engine) *WAVEPublicInfo {
+	return &WAVEPublicInfo{
+		eng: eng,
 	}
 }
 
 // ParamsForHierarchy accepts as input the multihash for a namespace (as the
 // "namespace" argument) and outputs the corresponding WKD-IBE parameters.
-func (wks *WAVEKeyStore) ParamsForHierarchy(ctx context.Context, namespace []byte) (*wkdibe.Params, error) {
+func (wpi *WAVEPublicInfo) ParamsForHierarchy(ctx context.Context, namespace []byte) (*wkdibe.Params, error) {
 	var err error
 	var werr wve.WVE
 
@@ -55,7 +51,7 @@ func (wks *WAVEKeyStore) ParamsForHierarchy(ctx context.Context, namespace []byt
 
 	var nsEntity *iapi.Entity
 	var nsValidity *engine.Validity
-	if nsEntity, nsValidity, err = wks.eng.LookupEntity(ctx, nsHash, nsLocation); err != nil {
+	if nsEntity, nsValidity, err = wpi.eng.LookupEntity(ctx, nsHash, nsLocation); err != nil {
 		return nil, err
 	}
 	if !nsValidity.Valid {
@@ -74,6 +70,24 @@ func (wks *WAVEKeyStore) ParamsForHierarchy(ctx context.Context, namespace []byt
 		}
 	}
 	return nil, errors.New("could not find WKD-IBE params in namespace entity")
+}
+
+// WAVEKeyStore implements the jedi.KeyStoreReader interface. It lifts a WAVE
+// entity's view of the attestation graph to JEDI's key storage interface. The
+// (abstract) key store consists of the keys in all attestations decryptable by
+// that WAVE entity.
+type WAVEKeyStore struct {
+	eng  *engine.Engine
+	wave *eapi.EAPI
+}
+
+// NewWAVEKeyStore creates and returns a new WAVEKeyStore. The entity whose
+// perpsective to use is implicit in the WAVE engine that is passed as an
+// argument to this function.
+func NewWAVEKeyStore(eng *engine.Engine) *WAVEKeyStore {
+	return &WAVEKeyStore{
+		eng: eng,
+	}
 }
 
 // KeyForPattern retrieves a key whose pattern matches the one provided as

--- a/jediutils/encoding.go
+++ b/jediutils/encoding.go
@@ -1,0 +1,33 @@
+package jediutils
+
+import (
+	"fmt"
+
+	"github.com/ucbrise/jedi-protocol-go"
+)
+
+// WAVEPatternEncoder implements the jedi.PatternEncoder interface. It
+// represents the algorithm to encode JEDI patterns in a way that is compatible
+// with WAVE's attestations and WAVE's other uses of WKD-IBE.
+type WAVEPatternEncoder struct{}
+
+// WAVEPatternEncoderSingleton is a single instance of WAVEPatternEncoder that
+// is meant to be used globally. This is possible because WAVEPatternEncoder
+// keeps absolutely no state.
+var WAVEPatternEncoderSingleton *WAVEPatternEncoder
+
+// Encode encodes a URI path and time path into a JEDI pattern in a way that is
+// compatible with WAVE's attestations and WAVE's other uses of WKD-IBE.
+func (wpe *WAVEPatternEncoder) Encode(uriPath jedi.URIPath, timePath jedi.TimePath, patternType jedi.PatternType) jedi.Pattern {
+	pattern := make(jedi.Pattern, 20)
+	switch patternType {
+	case jedi.PatternTypeDecryption:
+		pattern[0] = []byte("\x00jedi:decrypt")
+	case jedi.PatternTypeSigning:
+		pattern[0] = []byte("\x00jedi:sign")
+	default:
+		panic(fmt.Sprintf("Unknown key type %d\n", patternType))
+	}
+	jedi.EncodePattern(uriPath, timePath, pattern[1:])
+	return pattern
+}

--- a/wve/errors.go
+++ b/wve/errors.go
@@ -175,3 +175,5 @@ const MalformedPartition = 914
 const InvalidE2EEGrant = 915
 
 const ProofNotCached = 916
+
+const InvalidJEDIGrant = 917


### PR DESCRIPTION
This pull request adds "jedi:decrypt" and "jedi:sign" permissions to convey JEDI keys in attestations. The keys are encrypted according to the recipient, so they are conveyed in order and aren't discoverable in the same ways as the RDE keys.

Happy to squash these commits before merging if you prefer (though I thought I should keep the full history for your review).